### PR TITLE
* modified MHC-PRG and NextGen/HLAtypes to remove hard-coded dependen…

### DIFF
--- a/MHC-PRG.cpp
+++ b/MHC-PRG.cpp
@@ -21,15 +21,16 @@
 #include "MHC-PRG.h"
 #include "LocusCodeAllocation.h"
 #include "Data/HaplotypePanel.h"
-#include "Data/GenotypePanel.h"
+#include "Data/GenotypePanel.h" 
+
 #include "Graph/Graph.h"
 #include "Graph/Node.h"
 #include "Graph/HMM.h"
 #include "Graph/MultiHMM.h"
-#include "Graph/AlphaHMM.h"
+#include "Graph/AlphaHMM.h" 
+
 #include "NextGen/NextGen.h"
 #include "NextGen/simulationSuite.h"
-
 #include "NextGen/Validation.h"
 #include "NextGen/HLAtypes.h"
 
@@ -606,6 +607,7 @@ int main(int argc, char *argv[])
 				
 		std::string input_alignedReads;
 		std::string graph_dir;
+		std::string output_dir; 
 		std::string sampleID;
 
 		bool longUnpairedReads = false;
@@ -621,6 +623,11 @@ int main(int argc, char *argv[])
 			if(arguments.at(i) == "--graphDir")
 			{
 				graph_dir = arguments.at(i+1);
+			} 
+
+			if(arguments.at(i) == "--outputDir")
+			{
+				output_dir = arguments.at(i+1);
 			}
 
 			if(arguments.at(i) == "--sampleID")
@@ -661,7 +668,7 @@ int main(int argc, char *argv[])
 		
 		// todo activate
 		   
-		HLATypeInference(input_alignedReads, graph_dir, sampleID, false, loci_string, starting_haplotypes_perLocus_1_str, starting_haplotypes_perLocus_2_str, longUnpairedReads, MiSeq250bp);
+		HLATypeInference(input_alignedReads, graph_dir, output_dir , sampleID, false, loci_string, starting_haplotypes_perLocus_1_str, starting_haplotypes_perLocus_2_str, longUnpairedReads, MiSeq250bp);
 		
 		// HLAHaplotypeInference(input_alignedReads, graph_dir, sampleID, loci_string, starting_haplotypes_perLocus_1_str, starting_haplotypes_perLocus_2_str, longUnpairedReads);
 	}

--- a/NextGen/HLAtypes.cpp
+++ b/NextGen/HLAtypes.cpp
@@ -1647,7 +1647,7 @@ std::set<std::string> getCompletelyDefinedHLAAlleles(std::string graphDir, std::
 }
 
 
-void HLAHaplotypeInference(std::string alignedReads_file, std::string graphDir, std::string sampleName, std::string loci_str, std::string starting_haplotypes_perLocus_1_str, std::string starting_haplotypes_perLocus_2_str, bool longUnpairedReads)
+void HLAHaplotypeInference(std::string alignedReads_file, std::string graphDir, std::string outputDir, std::string sampleName, std::string loci_str, std::string starting_haplotypes_perLocus_1_str, std::string starting_haplotypes_perLocus_2_str, bool longUnpairedReads)
 {
 	
 	std::cout << Utilities::timestamp() << "HLAHaplotypeInference(..): Start.\n";
@@ -1788,7 +1788,7 @@ void HLAHaplotypeInference(std::string alignedReads_file, std::string graphDir, 
 		Utilities::makeDir("../tmp/hla");
 	}
 
-	std::string outputDirectory = "../tmp/hla/"+sampleName;
+	std::string outputDirectory = outputDir + "/hla/" +sampleName;
 	if(! Utilities::directoryExists(outputDirectory))
 	{
 		Utilities::makeDir(outputDirectory);
@@ -3851,7 +3851,7 @@ void HLAHaplotypeInference(std::string alignedReads_file, std::string graphDir, 
 	outputFN_parameters_outputStream.close();
 }
 
-void HLATypeInference(std::string alignedReads_file, std::string graphDir, std::string sampleName, bool restrictToFullHaplotypes, std::string& forReturn_lociString, std::string& forReturn_starting_haplotype_1, std::string& forReturn_starting_haplotype_2, bool longUnpairedReads, bool MiSeq250bp)
+void HLATypeInference(std::string alignedReads_file, std::string graphDir, std::string outputDir, std::string sampleName, bool restrictToFullHaplotypes, std::string& forReturn_lociString, std::string& forReturn_starting_haplotype_1, std::string& forReturn_starting_haplotype_2, bool longUnpairedReads, bool MiSeq250bp)
 {
 	std::string graph = graphDir + "/graph.txt";
 	assert(Utilities::fileReadable(graph));
@@ -4056,12 +4056,14 @@ void HLATypeInference(std::string alignedReads_file, std::string graphDir, std::
 	double alignmentStats_paired_fractionOK_avg = (alignments_paired.size() > 0) ? (alignmentStats_paired_fractionOK_sum / (2.0* (double)alignments_paired.size())) : 0;
 	double alignmentStats_unpaired_fractionOK_avg = (alignments_unpaired.size() > 0) ? (alignmentStats_unpaired_fractionOK_sum / (2.0* (double)alignments_unpaired.size())) : 0;
 
-	if(! Utilities::directoryExists("../tmp/hla"))
+
+	if(! Utilities::directoryExists(outputDir + "/hla"))
 	{
-		Utilities::makeDir("../tmp/hla");
+		Utilities::makeDir( outputDir + "/hla");
 	}
 
-	std::string outputDirectory = "../tmp/hla/"+sampleName;
+	std::string outputDirectory = outputDir + "/hla/" + sampleName; 
+
 	if(! Utilities::directoryExists(outputDirectory))
 	{
 		Utilities::makeDir(outputDirectory);

--- a/NextGen/HLAtypes.h
+++ b/NextGen/HLAtypes.h
@@ -13,7 +13,7 @@
 #include <map>
 
 
-void HLATypeInference(std::string alignedReads_file, std::string graphDir, std::string sampleName, bool restrictToFullHaplotypes, std::string& forReturn_lociString, std::string& forReturn_starting_haplotype_1, std::string& forReturn_starting_haplotype_2, bool longUnpairedReads, bool MiSeq250bp = false);
+void HLATypeInference(std::string alignedReads_file, std::string graphDir, std::string outputDir, std::string sampleName, bool restrictToFullHaplotypes, std::string& forReturn_lociString, std::string& forReturn_starting_haplotype_1, std::string& forReturn_starting_haplotype_2, bool longUnpairedReads, bool MiSeq250bp = false);
 void HLAHaplotypeInference(std::string alignedReads_file, std::string graphDir, std::string sampleName, std::string loci_str, std::string starting_haplotype_1, std::string starting_haplotype_2, bool longUnpairedReads);
 
 void simulateHLAreads(std::string graphDir, int nIndividuals, bool exon23, bool perturbHaplotypes, bool readError, std::string outputDirectory, std::string qualityMatrixFile, int readLength, double insertSize_mean, double insertSize_sd, double haploidCoverage);


### PR DESCRIPTION
I modified MHC-PRG and the dependent NextGen/HLAtypes files as they relied on an existing '/tmp' directory to write output. The changes allow more configurability to use MHC-PRG in a multi-user environment. 

- option outputDir added to NextGen/HLAtypes calls 

  MHC-PRG's "HLATypeInference" function now takes an additional  parameter which is
  --outputDir.
 Todo: adjust the perl script(s) which call MHC-PRG *** HLATypeInference ...

Note: Previously the program died with this error if the tmp dir did not exist: 

```
 terminate called after throwing an instance of 'boost::filesystem::filesystem_error
 sh: line 1: 106250 Segmentation fault      (core dumped) MHC-PRG domode HLATypeInference
 got return code 35584 at HLAtypeinference.pl line 605.
```